### PR TITLE
add nur to registry

### DIFF
--- a/flake-registry.json
+++ b/flake-registry.json
@@ -82,6 +82,17 @@
       }
     },
     {
+      "from": {
+        "id": "nur",
+        "type": "indirect"
+      },
+      "to": {
+        "owner": "nix-community",
+        "repo": "NUR",
+        "type": "github"
+      }
+    },
+    {
       "_comment": "Remove this soon (20200210)",
       "from": {
         "id": "nixpkgs",


### PR DESCRIPTION
[NUR](https://github.com/nix-community/NUR) is a meta-repository of
packages/NixOS modules/overlays/home-manager modules.
We currently have 106 different repositories.
At the moment we only expose packages via an overlay in our nix flake:

  https://github.com/nix-community/NUR/#flake-support

Each user has its own namespace in NUR.
Expressions are only reviewed coarse grained so users
are advised to verify the used user repository directly.
NUR performs evaluation updates against each repository before
updating the reference in the repo NUR metadata.
User repositories are imported via fetchzip with checksum
so pure evaluation with flakes works.

We also provide a package search here for discoverability:
https://nur.nix-community.org/

In future we might explore different approaches to expose NUR via flakes,
however given that nix flakes will stay experimental for a while,
this can take some time.