### PR TITLE
add mach-nix (access python packages from pypi)

### DIFF
--- a/flake-registry.json
+++ b/flake-registry.json
@@ -36,6 +36,17 @@
     },
     {
       "from": {
+        "id": "mach-nix",
+        "type": "indirect"
+      },
+      "to": {
+        "owner": "DavHau",
+        "repo": "mach-nix",
+        "type": "github"
+      }
+    },
+    {
+      "from": {
         "id": "nimble",
         "type": "indirect"
       },


### PR DESCRIPTION
Hello, I'd like to add [mach-nix](https://github.com/DavHau/mach-nix) to the flake registry.

Mach-nix allows users to access python packages directly from pypi. For example to get a shell with the snake game:
```
nix develop mach-nix#shellWith.console-snake
```
or, to open a python shell with an arbitrary selection of libraries:
```
nix run mach-nix#with.requests.tensorflow.aiohttp
```