### PR TITLE
Add gemini flake

### DIFF
--- a/flake-registry.json
+++ b/flake-registry.json
@@ -25,6 +25,17 @@
     },
     {
       "from": {
+        "id": "gemini",
+        "type": "indirect"
+      },
+      "to": {
+        "owner": "nix-community",
+        "repo": "flake-gemini",
+        "type": "github"
+      }
+    },
+    {
+      "from": {
         "id": "hydra",
         "type": "indirect"
       },


### PR DESCRIPTION
Software related to the experimental Gemini protocol.

---

Gemini is still an experiment so I think its best to keep packages and NixOS modules out of the monorepo.

https://github.com/nix-community/flake-gemini