### PR TITLE
Add home-manager

### DIFF
--- a/flake-registry.json
+++ b/flake-registry.json
@@ -25,6 +25,17 @@
     },
     {
       "from": {
+        "id": "home-manager",
+        "type": "indirect"
+      },
+      "to": {
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    {
+      "from": {
         "id": "hydra",
         "type": "indirect"
       },


### PR DESCRIPTION
A good chunk of Nix users use home-manager, and thanks to nix-community/home-manager#1913 (as well as nix-community/home-manager#1934) they can run the home-manager script directly using `nix run`, so this seems like an obvious entry to add.