### PR TITLE
add SchildiChat to registry

### DIFF
--- a/flake-registry.json
+++ b/flake-registry.json
@@ -166,6 +166,17 @@
         "repo": "nickel",
         "type": "github"
       }
+    },
+    {
+      "from": {
+        "id": "schildichat",
+        "type": "indirect"
+      },
+      "to": {
+        "owner": "SchildiChat",
+        "repo": "schildichat-desktop",
+        "type": "github"
+      }
     }
   ],
   "version": 2


### PR DESCRIPTION
SchildiChat Web/Desktop is a fork of Element Web/Desktop.

The most important changes of SchildiChat Web/Desktop compared to Element Web/Desktop are:
- A unified chat list for both direct and group chats
- Message bubbles
- Bigger items in the room list
- … and more!