### PR TITLE
add dreampkgs

### DIFF
--- a/flake-registry.json
+++ b/flake-registry.json
@@ -14,6 +14,17 @@
     },
     {
       "from": {
+        "id": "dreampkgs",
+        "type": "indirect"
+      },
+      "to": {
+        "owner": "nix-community",
+        "repo": "dreampkgs",
+        "type": "github"
+      }
+    },
+    {
+      "from": {
         "id": "dwarffs",
         "type": "indirect"
       },


### PR DESCRIPTION
[dreampkgs](https://github.com/nix-community/dreampkgs) is a collection of software packages managed with [dream2nix](https://github.com/nix-community/dream2nix), a framework for automated packaging.

We'd like our users and maintainers to have easier access to our package collection and therefore we would appreciate an entry in the registry.