### PR TITLE
Add pridefetch to the flake registry

### DIFF
--- a/flake-registry.json
+++ b/flake-registry.json
@@ -288,6 +288,17 @@
         "repo": "bundlers",
         "type": "github"
       }
+    },
+    {
+      "from": {
+        "id": "pridefetch",
+        "type": "indirect"
+      },
+      "to": {
+        "owner": "SpyHoodle",
+        "repo": "pridefetch",
+        "type": "github"
+      }
     }
   ],
   "version": 2


### PR DESCRIPTION
This PR adds the pridefetch flake to the resgistry. Pridefetch is a small terminal app to print out a pride flag and some system information in a terminal.