### PR TITLE
Remove ref from nixos-homepage since it does not exist

### DIFF
--- a/flake-registry.json
+++ b/flake-registry.json
@@ -184,7 +184,6 @@
       },
       "to": {
         "owner": "NixOS",
-        "ref": "flake",
         "repo": "nixos-homepage",
         "type": "github"
       }


### PR DESCRIPTION
Also it has a flake.nix now in the default branch.