### PR TITLE
Add sops-nix flake

### DIFF
--- a/flake-registry.json
+++ b/flake-registry.json
@@ -353,6 +353,17 @@
         "repo": "helix",
         "type": "github"
       }
+    },
+    {
+      "from": {
+        "id": "sops-nix",
+        "type": "indirect"
+      },
+      "to": {
+        "owner": "Mic92",
+        "repo": "sops-nix",
+        "type": "github"
+      }
     }
   ],
   "version": 2


### PR DESCRIPTION
A widely used tool for secrets deployment under NixOS.