### PR TITLE
Add composable

### DIFF
--- a/flake-registry.json
+++ b/flake-registry.json
@@ -36,6 +36,17 @@
     },
     {
       "from": {
+        "id": "composable",
+        "type": "indirect"
+      },
+      "to": {
+        "owner": "ComposableFi",
+        "repo": "composable",
+        "type": "github"
+      }
+    },
+    {
+      "from": {
         "id": "dreampkgs",
         "type": "indirect"
       },


### PR DESCRIPTION
https://github.com/ComposableFi/composable

Provides infrastructure packages that are used within blockchain ecosystems. Specifically within the DotSama ecosystem for now, but also providing tools for the Cosmos and EVM soon.