### PR TITLE
Add nix-on-droid

### DIFF
--- a/flake-registry.json
+++ b/flake-registry.json
@@ -364,6 +364,17 @@
         "repo": "sops-nix",
         "type": "github"
       }
+    },
+    {
+      "from": {
+        "id": "nix-on-droid",
+        "type": "indirect"
+      },
+      "to": {
+        "owner": "t184256",
+        "repo": "nix-on-droid",
+        "type": "github"
+      }
     }
   ],
   "version": 2


### PR DESCRIPTION
[Nix-on-Droid][1] is a Linux userland based on Nix and Nixpkgs (though not NixOS) that runs on Android inside a fork of the terminal emulator Termux uses. It seems to have a fair number of users given the target audience, although exact numbers are not readily available because builds are only distributed [on F-Droid][2]. The maintainer [agrees][3] with my wish that it be included in the global registry.

I’m not sure which order registry entries are supposed to be in, so I followed recent inclusions and put the entry for `nix-on-droid` at the end.

[1]: https://github.com/t184256/nix-on-droid
[2]: https://f-droid.org/packages/com.termux.nix
[3]: https://github.com/t184256/nix-on-droid/issues/222