### PR TITLE
add: disko, declaratively formatting disk tool

### DIFF
--- a/flake-registry.json
+++ b/flake-registry.json
@@ -47,6 +47,17 @@
     },
     {
       "from": {
+        "id": "disko",
+        "type": "indirect"
+      },
+      "to": {
+        "owner": "nix-community",
+        "repo": "disko",
+        "type": "github"
+      }
+    },
+    {
+      "from": {
         "id": "dreampkgs",
         "type": "indirect"
       },


### PR DESCRIPTION
since this is so useful during bootsrapping a bare system, it should be included into the registy to shorten the ux to:
`nix run disko ...`