### PR TITLE
Add Standard

### DIFF
--- a/flake-registry.json
+++ b/flake-registry.json
@@ -364,6 +364,17 @@
         "repo": "sops-nix",
         "type": "github"
       }
+    },
+    {
+      "from": {
+        "id": "std",
+        "type": "indirect"
+      },
+      "to": {
+        "owner": "divnix",
+        "repo": "std",
+        "type": "github"
+      }
     }
   ],
   "version": 2


### PR DESCRIPTION
[Standard](https://github.com/divnix/std) is a Flakes DevOps framework to keep large code-bases organized with a friendly cli/tui.

---

Having this part of the registry helps shorten the tool UX to `nix run std` (if people don't want to 'install' it).

In other words, having this in the registry is a token for lowering entry barriers as much as possible.

That's helpful as Standard strives to provide the benefits of Nix in a sort of managed service model to non-nixers via that TUI/CLI.
