### PR TITLE
add systems

### DIFF
--- a/flake-registry.json
+++ b/flake-registry.json
@@ -356,6 +356,17 @@
     },
     {
       "from": {
+        "id": "systems",
+        "type": "indirect"
+      },
+      "to": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    {
+      "from": {
         "id": "helix",
         "type": "indirect"
       },


### PR DESCRIPTION
This allows flake users to make the systems list externally extensible.
The default systems is:
```
[
  "aarch64-darwin"
  "aarch64-linux"
  "x86_64-darwin"
  "x86_64-linux"
]
```

See https://github.com/nix-systems/nix-systems for a full explanation
