### PR TITLE
rename nix-darwin to darwin, following precedent for that project

### DIFF
--- a/flake-registry.json
+++ b/flake-registry.json
@@ -201,7 +201,7 @@
     },
     {
       "from": {
-        "id": "nix-darwin",
+        "id": "darwin",
         "type": "indirect"
       },
       "to": {


### PR DESCRIPTION
rename nix-darwin to darwin

fixes https://github.com/LnL7/nix-darwin/issues/649

This is a backwards-incompatible change, but I think the few users, if any, utilizing this registry entry can update their input references. Otherwise, a duplicate entry could be created.

CC @LnL7