### PR TITLE
add: agenix flake

### DIFF
--- a/flake-registry.json
+++ b/flake-registry.json
@@ -400,6 +400,17 @@
     },
     {
       "from": {
+        "id": "agenix",
+        "type": "indirect"
+      },
+      "to": {
+        "owner": "ryantm",
+        "repo": "agenix",
+        "type": "github"
+      }
+    },
+    {
+      "from": {
         "id": "sops-nix",
         "type": "indirect"
       },


### PR DESCRIPTION
A widely used tool for secrets deployment under NixOS.


* *The namespace has a limited size* agenix is a fairly long and unique name
* *Common names should be avoided to prevent confusion if a user mistypes an input in their flake.nix and it resolves to another input via the registry.* it is not a common name and or close to any other name in the community
* *The shortcut must offer clear utility to the NixOS ecosystem; it is not intended to showcase random projects.* github:ryantm/agenix is so long :wink: , definitely clear utility to be able to write agenix by itself.
* *Project popularity is taken into account.* has over 800 GitHub stars and its own cat memes at nixcon