### PR TITLE
Add nixos-anywhere

### DIFF
--- a/flake-registry.json
+++ b/flake-registry.json
@@ -267,6 +267,17 @@
     },
     {
       "from": {
+        "id": "nixos-anywhere",
+        "type": "indirect"
+      },
+      "to": {
+        "owner": "nix-community",
+        "repo": "nixos-anywhere",
+        "type": "github"
+      }
+    },
+    {
+      "from": {
         "id": "nixos-hardware",
         "type": "indirect"
       },


### PR DESCRIPTION
1500 stars, 100+ forks

Successor to `nixos-infect`, very useful tool that is primarily going to be used with `nix run` as a local checkout is rarely ever necessary

cc @zimbatm 