### PR TITLE
Update nix-darwin owner

### DIFF
--- a/flake-registry.json
+++ b/flake-registry.json
@@ -238,7 +238,7 @@
         "type": "indirect"
       },
       "to": {
-        "owner": "LnL7",
+        "owner": "nix-darwin",
         "repo": "nix-darwin",
         "type": "github"
       }


### PR DESCRIPTION
This entry still works fine given GitHub's redirect but the repo [has indeed moved](https://github.com/nix-darwin/nix-darwin) so we might as well keep this in sync with recent developments.
