### PR TITLE
bump CI ubuntu from 20.04 to 24.04

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
       - uses: cachix/install-nix-action@v20


### PR DESCRIPTION
ci is not working as of now: https://github.com/NixOS/flake-registry/pull/57/checks?check_run_id=43827536164
here is more context: https://github.com/actions/runner-images/issues/11101

