### PR TITLE
Add qfetch to registry

### DIFF
--- a/flake-registry.json
+++ b/flake-registry.json
@@ -400,6 +400,17 @@
     },
     {
       "from": {
+        "id": "qfetch",
+        "type": "indirect"
+      },
+      "to": {
+        "owner": "quixaq",
+        "repo": "qfetch",
+        "type": "github"
+      }
+    },
+    {
+      "from": {
         "id": "sops-nix",
         "type": "indirect"
       },


### PR DESCRIPTION
Add `qfetch` to the registry, it's a very fast system fetch tool. The project is in `github:quixaq/qfetch` and it provides a flake with configuration for Nix.