### PR TITLE
Pull nixpkgs as tarball from channels.nixos.org

### DIFF
--- a/flake-registry.json
+++ b/flake-registry.json
@@ -337,10 +337,8 @@
         "type": "indirect"
       },
       "to": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
+        "type": "tarball",
+        "url": "https://channels.nixos.org/nixpkgs-unstable/nixexprs.tar.xz"
       }
     },
     {


### PR DESCRIPTION
It comes with IPv6 support, no rate-limiting and is well distributed thanks to Fastly.

I'm frankly not sure if this is correct, `./ci.sh` works.