### PR TITLE
Pull nixpkgs as tarball from channels.nixos.org (another try)

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
-# Test that the flake-registry.json format is sorted & valid
+# Test that the flake-registry.json format is valid
 set -euo pipefail
 
 cd "$(dirname "$0")"
 
 # Ensure current flake-registry.json file is sorted.
-nix registry list --tarball-ttl 0 --flake-registry "$PWD/flake-registry.json" \
-  | grep -- '^global ' | LC_ALL=C sort -u -c
+nix registry list --tarball-ttl 0 --flake-registry "$PWD/flake-registry.json" |
+    grep -- '^global '
 
 nix run --flake-registry "$PWD/flake-registry.json" nixpkgs#hello

--- a/flake-registry.json
+++ b/flake-registry.json
@@ -336,6 +336,89 @@
         "id": "nixpkgs",
         "type": "indirect"
       },
+      "exact": true,
+      "to": {
+        "type": "tarball",
+        "url": "https://channels.nixos.org/nixpkgs-unstable/nixexprs.tar.xz"
+      }
+    },
+    {
+      "from": {
+        "id": "nixpkgs",
+        "type": "indirect",
+        "ref": "nixpkgs-unstable"
+      },
+      "exact": true,
+      "to": {
+        "type": "tarball",
+        "url": "https://channels.nixos.org/nixpkgs-unstable/nixexprs.tar.xz"
+      }
+    },
+    {
+      "from": {
+        "id": "nixpkgs",
+        "type": "indirect",
+        "ref": "nixos-unstable"
+      },
+      "exact": true,
+      "to": {
+        "type": "tarball",
+        "url": "https://channels.nixos.org/nixos-unstable/nixexprs.tar.xz"
+      }
+    },
+    {
+      "from": {
+        "id": "nixpkgs",
+        "type": "indirect",
+        "ref": "nixos-unstable-small"
+      },
+      "exact": true,
+      "to": {
+        "type": "tarball",
+        "url": "https://channels.nixos.org/nixos-unstable-small/nixexprs.tar.xz"
+      }
+    },
+    {
+      "from": {
+        "id": "nixpkgs",
+        "type": "indirect",
+        "ref": "nixos-26.05"
+      },
+      "exact": true,
+      "to": {
+        "type": "tarball",
+        "url": "https://channels.nixos.org/nixos-26.05/nixexprs.tar.xz"
+      }
+    },
+    {
+      "from": {
+        "id": "nixpkgs",
+        "type": "indirect",
+        "ref": "nixos-26.05-small"
+      },
+      "exact": true,
+      "to": {
+        "type": "tarball",
+        "url": "https://channels.nixos.org/nixos-26.05-small/nixexprs.tar.xz"
+      }
+    },
+    {
+      "from": {
+        "id": "nixpkgs",
+        "type": "indirect",
+        "ref": "nixpkgs-26.05-darwin"
+      },
+      "exact": true,
+      "to": {
+        "type": "tarball",
+        "url": "https://channels.nixos.org/nixpkgs-26.05-darwin/nixexprs.tar.xz"
+      }
+    },
+    {
+      "from": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      },
       "to": {
         "owner": "NixOS",
         "ref": "nixpkgs-unstable",


### PR DESCRIPTION
Actually working solution for https://github.com/NixOS/flake-registry/pull/61. Don't even ask what "exact" is doing here, but it's load-bearing for this to work. Stuff like `nix flake metadata nixpkgs/nixos-26.05` (and `nix flake metadata nixpkgs`) uses the channel tarballs, while `nix flake metadata nixpkgs/master` falls back to `github:nixos/nixpkgs/master`.